### PR TITLE
Fixes fatal error in Frosit\Utils\Mysql\MysqliDb::_dynamicBindResults

### DIFF
--- a/src/Frosit/Utils/Mysql/MysqliDb.php
+++ b/src/Frosit/Utils/Mysql/MysqliDb.php
@@ -1447,7 +1447,7 @@ class MysqliDb
      *
      * @return array The results of the SQL fetch.
      */
-    protected function _dynamicBindResults(mysqli_stmt $stmt)
+    protected function _dynamicBindResults(\mysqli_stmt $stmt)
     {
         $parameters = array();
         $results = array();


### PR DESCRIPTION
Fixes PHP Fatal error in Frosit\Utils\Mysql\MysqliDb::_dynamicBindResults method

> PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Frosit\Utils\Mysql\MysqliDb::_dynamicBindResults() must be an instance of Frosit\Utils\Mysql\mysqli_stmt, instance of mysqli_stmt given, called in /var/www/sites/e-matras/www/lib/n98-magerun/modules/Rewritetoolset/src/Frosit/Utils/Mysql/MysqliDb.php on line 451 and defined in /var/www/sites/e-matras/www/lib/n98-magerun/modules/Rewritetoolset/src/Frosit/Utils/Mysql/MysqliDb.php:1450